### PR TITLE
feat: FrxEthRewarder

### DIFF
--- a/src/contracts/FraxFerry.sol
+++ b/src/contracts/FraxFerry.sol
@@ -18,349 +18,371 @@ pragma solidity >=0.8.0;
 // Dennis: https://github.com/denett
 
 /*
-** Modus operandi:
-** - User sends tokens to the contract. This transaction is stored in the contract.
-** - Captain queries the source chain for transactions to ship.
-** - Captain sends batch (start, end, hash) to start the trip,
-** - Crewmembers check the batch and can dispute it if it is invalid.
-** - Non disputed batches can be executed by the first officer by providing the transactions as calldata. 
-** - Hash of the transactions must be equal to the hash in the batch. User receives their tokens on the other chain.
-** - In case there was a fraudulent transaction (a hacker for example), the owner can cancel a single transaction, such that it will not be executed.
-** - The owner can manually manage the tokens in the contract and must make sure it has enough funds.
-**
-** What must happen for a false batch to be executed:
-** - Captain is tricked into proposing a batch with a false hash
-** - All crewmembers bots are offline/censured/compromised and no one disputes the proposal
-**
-** Other risks:
-** - Reorgs on the source chain. Avoided, by only returning the transactions on the source chain that are at least one hour old.
-** - Rollbacks of optimistic rollups. Avoided by running a node.
-** - Operators do not have enough time to pause the chain after a fake proposal. Avoided by requiring a minimal amount of time between sending the proposal and executing it.
-*/
+ ** Modus operandi:
+ ** - User sends tokens to the contract. This transaction is stored in the contract.
+ ** - Captain queries the source chain for transactions to ship.
+ ** - Captain sends batch (start, end, hash) to start the trip,
+ ** - Crewmembers check the batch and can dispute it if it is invalid.
+ ** - Non disputed batches can be executed by the first officer by providing the transactions as calldata.
+ ** - Hash of the transactions must be equal to the hash in the batch. User receives their tokens on the other chain.
+ ** - In case there was a fraudulent transaction (a hacker for example), the owner can cancel a single transaction, such that it will not be executed.
+ ** - The owner can manually manage the tokens in the contract and must make sure it has enough funds.
+ **
+ ** What must happen for a false batch to be executed:
+ ** - Captain is tricked into proposing a batch with a false hash
+ ** - All crewmembers bots are offline/censured/compromised and no one disputes the proposal
+ **
+ ** Other risks:
+ ** - Reorgs on the source chain. Avoided, by only returning the transactions on the source chain that are at least one hour old.
+ ** - Rollbacks of optimistic rollups. Avoided by running a node.
+ ** - Operators do not have enough time to pause the chain after a fake proposal. Avoided by requiring a minimal amount of time between sending the proposal and executing it.
+ */
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol";
 
 contract Fraxferry {
-   IERC20 immutable public token;
-   IERC20 immutable public targetToken;
-   uint immutable public chainid;
-   uint immutable public targetChain;   
-   
-   address public owner;
-   address public nominatedOwner;
-   address public captain;
-   address public firstOfficer;
-   mapping(address => bool) public crewmembers;
-   mapping(address => bool) public fee_exempt_addrs;
+    IERC20 public immutable token;
+    IERC20 public immutable targetToken;
+    uint256 public immutable chainid;
+    uint256 public immutable targetChain;
 
-   bool public paused;
-   
-   uint public MIN_WAIT_PERIOD_ADD=3600; // Minimal 1 hour waiting
-   uint public MIN_WAIT_PERIOD_EXECUTE=79200; // Minimal 22 hour waiting
-   uint public FEE_RATE=10;      // 0.1% fee
-   uint public FEE_MIN=5*1e18;   // 5 token min fee
-   uint public FEE_MAX=100*1e18; // 100 token max fee
-   
-   uint constant MAX_FEE_RATE=100; // Max fee rate is 1%
-   uint constant MAX_FEE_MIN=100e18; // Max minimum fee is 100 tokens
-   uint constant MAX_FEE_MAX=1000e18; // Max fee is 1000 tokens
-   
-   uint constant public REDUCED_DECIMALS=1e10;
-   
-   Transaction[] public transactions;
-   mapping(uint => bool) public cancelled;
-   uint public executeIndex;
-   Batch[] public batches;
-   
-   struct Transaction {
-      address user;
-      uint64 amount;
-      uint32 timestamp;
-   }
-   
-   struct Batch {
-      uint64 start;
-      uint64 end;
-      uint64 departureTime;
-      uint64 status;
-      bytes32 hash;
-   }
-   
-   struct BatchData {
-      uint startTransactionNo;
-      Transaction[] transactions;
-   }
+    address public owner;
+    address public nominatedOwner;
+    address public captain;
+    address public firstOfficer;
+    mapping(address => bool) public crewmembers;
+    mapping(address => bool) public fee_exempt_addrs;
 
-   constructor(address _token, uint _chainid, address _targetToken, uint _targetChain) {
-      //require (block.chainid==_chainid,"Wrong chain");
-      chainid=_chainid;
-      token = IERC20(_token);
-      targetToken = IERC20(_targetToken);
-      owner = msg.sender;
-      targetChain = _targetChain;
-   }
-   
-   
-   // ############## Events ##############
-   
-   event Embark(address indexed sender, uint index, uint amount, uint amountAfterFee, uint timestamp);
-   event Disembark(uint start, uint end, bytes32 hash); 
-   event Depart(uint batchNo,uint start,uint end,bytes32 hash); 
-   event RemoveBatch(uint batchNo);
-   event DisputeBatch(uint batchNo, bytes32 hash);
-   event Cancelled(uint index, bool cancel);
-   event Pause(bool paused);
-   event OwnerNominated(address indexed newOwner);
-   event OwnerChanged(address indexed previousOwner,address indexed newOwner);
-   event SetCaptain(address indexed previousCaptain, address indexed newCaptain);   
-   event SetFirstOfficer(address indexed previousFirstOfficer, address indexed newFirstOfficer);
-   event SetCrewmember(address indexed crewmember,bool set); 
-   event SetFee(uint previousFeeRate, uint feeRate,uint previousFeeMin, uint feeMin,uint previousFeeMax, uint feeMax);
-   event SetMinWaitPeriods(uint previousMinWaitAdd,uint previousMinWaitExecute,uint minWaitAdd,uint minWaitExecute); 
-   event FeeExemptToggled(address addr,bool is_fee_exempt); 
-   
+    bool public paused;
 
-   // ############## Modifiers ##############
-   
-   modifier isOwner() {
-      require (msg.sender==owner,"Not owner");
-      _;
-   }
-   
-   modifier isCaptain() {
-      require (msg.sender==captain,"Not captain");
-      _;
-   }
-   
-   modifier isFirstOfficer() {
-      require (msg.sender==firstOfficer,"Not first officer");
-      _;
-   }   
-    
-   modifier isCrewmember() {
-      require (crewmembers[msg.sender] || msg.sender==owner || msg.sender==captain || msg.sender==firstOfficer,"Not crewmember");
-      _;
-   }
-   
-   modifier notPaused() {
-      require (!paused,"Paused");
-      _;
-   } 
-   
-   // ############## Ferry actions ##############
-   
-   function embarkWithRecipient(uint amount, address recipient) public notPaused {
-      amount = (amount/REDUCED_DECIMALS)*REDUCED_DECIMALS; // Round amount to fit in data structure
-      uint fee;
-      if(fee_exempt_addrs[msg.sender]) fee = 0;
-      else {
-         fee = Math.min(Math.max(FEE_MIN,amount*FEE_RATE/10000),FEE_MAX);
-      }
-      require (amount>fee,"Amount too low");
-      require (amount/REDUCED_DECIMALS<=type(uint64).max,"Amount too high");
-      TransferHelper.safeTransferFrom(address(token),msg.sender,address(this),amount); 
-      uint64 amountAfterFee = uint64((amount-fee)/REDUCED_DECIMALS);
-      emit Embark(recipient,transactions.length,amount,amountAfterFee*REDUCED_DECIMALS,block.timestamp);
-      transactions.push(Transaction(recipient,amountAfterFee,uint32(block.timestamp)));   
-   }
-   
-   function embark(uint amount) public {
-      embarkWithRecipient(amount, msg.sender) ;
-   }
+    uint256 public MIN_WAIT_PERIOD_ADD = 3600; // Minimal 1 hour waiting
+    uint256 public MIN_WAIT_PERIOD_EXECUTE = 79_200; // Minimal 22 hour waiting
+    uint256 public FEE_RATE = 10; // 0.1% fee
+    uint256 public FEE_MIN = 5 * 1e18; // 5 token min fee
+    uint256 public FEE_MAX = 100 * 1e18; // 100 token max fee
 
-   function embarkWithSignature(
-      uint256 _amount,
-      address recipient,
-      uint256 deadline,
-      bool approveMax,
-      uint8 v,
-      bytes32 r,
-      bytes32 s
-   ) public {
-      uint amount = approveMax ? type(uint256).max : _amount;
-      IERC20Permit(address(token)).permit(msg.sender, address(this), amount, deadline, v, r, s);
-      embarkWithRecipient(amount,recipient);
-   }   
-   
-   function depart(uint start, uint end, bytes32 hash) external notPaused isCaptain {
-      require ((batches.length==0 && start==0) || (batches.length>0 && start==batches[batches.length-1].end+1),"Wrong start");
-      require (end>=start && end<type(uint64).max,"Wrong end");
-      batches.push(Batch(uint64(start),uint64(end),uint64(block.timestamp),0,hash));
-      emit Depart(batches.length-1,start,end,hash);
-   }
-   
-   function disembark(BatchData calldata batchData) external notPaused isFirstOfficer {
-      Batch memory batch = batches[executeIndex++];
-      require (batch.status==0,"Batch disputed");
-      require (batch.start==batchData.startTransactionNo,"Wrong start");
-      require (batch.start+batchData.transactions.length-1==batch.end,"Wrong size");
-      require (block.timestamp-batch.departureTime>=MIN_WAIT_PERIOD_EXECUTE,"Too soon");
-      
-      bytes32 hash = keccak256(abi.encodePacked(targetChain, targetToken, chainid, token, batch.start));
-      for (uint i=0;i<batchData.transactions.length;++i) {
-         if (!cancelled[batch.start+i]) {
-            TransferHelper.safeTransfer(address(token),batchData.transactions[i].user,batchData.transactions[i].amount*REDUCED_DECIMALS);
-         }
-         hash = keccak256(abi.encodePacked(hash, batchData.transactions[i].user,batchData.transactions[i].amount));
-      }
-      require (batch.hash==hash,"Wrong hash");
-      emit Disembark(batch.start,batch.end,hash);
-   }
-   
-   function removeBatches(uint batchNo) external isOwner {
-      require (executeIndex<=batchNo,"Batch already executed");
-      while (batches.length>batchNo) batches.pop();
-      emit RemoveBatch(batchNo);
-   }
-   
-   function disputeBatch(uint batchNo, bytes32 hash) external isCrewmember {
-      require (batches[batchNo].hash==hash,"Wrong hash");
-      require (executeIndex<=batchNo,"Batch already executed");
-      require (batches[batchNo].status==0,"Batch already disputed");
-      batches[batchNo].status=1; // Set status on disputed
-      _pause(true);
-      emit DisputeBatch(batchNo,hash);
-   }
-   
-   function pause() external isCrewmember {
-      _pause(true);
-   }
-   
-   function unPause() external isOwner {
-      _pause(false);
-   }   
-   
-   function _pause(bool _paused) internal {
-      paused=_paused;
-      emit Pause(_paused);
-   } 
-   
-   function _jettison(uint index, bool cancel) internal {
-      require (executeIndex==0 || index>batches[executeIndex-1].end,"Transaction already executed");
-      cancelled[index]=cancel;
-      emit Cancelled(index,cancel);
-   }
-   
-   function jettison(uint index, bool cancel) external isOwner {
-      _jettison(index,cancel);
-   }
-   
-   function jettisonGroup(uint[] calldata indexes, bool cancel) external isOwner {
-      for (uint i=0;i<indexes.length;++i) {
-         _jettison(indexes[i],cancel);
-      }
-   }   
-   
-   // ############## Parameters management ##############
-   
-   function setFee(uint _FEE_RATE, uint _FEE_MIN, uint _FEE_MAX) external isOwner {
-      require(_FEE_RATE<MAX_FEE_RATE);
-      require(_FEE_MIN<MAX_FEE_MIN);
-      require(_FEE_MAX<MAX_FEE_MAX);
-      emit SetFee(FEE_RATE,_FEE_RATE,FEE_MIN,_FEE_MIN,FEE_MAX,_FEE_MAX);
-      FEE_RATE=_FEE_RATE;
-      FEE_MIN=_FEE_MIN;
-      FEE_MAX=_FEE_MAX;
-   }
-   
-   function setMinWaitPeriods(uint _MIN_WAIT_PERIOD_ADD, uint _MIN_WAIT_PERIOD_EXECUTE) external isOwner {
-      require(_MIN_WAIT_PERIOD_ADD>=3600 && _MIN_WAIT_PERIOD_EXECUTE>=3600,"Period too short");
-      emit SetMinWaitPeriods(MIN_WAIT_PERIOD_ADD, MIN_WAIT_PERIOD_EXECUTE,_MIN_WAIT_PERIOD_ADD, _MIN_WAIT_PERIOD_EXECUTE);
-      MIN_WAIT_PERIOD_ADD=_MIN_WAIT_PERIOD_ADD;
-      MIN_WAIT_PERIOD_EXECUTE=_MIN_WAIT_PERIOD_EXECUTE;
-   }
-   
-   // ############## Roles management ##############
-   
-   function nominateNewOwner(address newOwner) external isOwner {
-      nominatedOwner = newOwner;
-      emit OwnerNominated(newOwner);
-   }   
-   
-   function acceptOwnership() external {
-      require(msg.sender == nominatedOwner, "You must be nominated before you can accept ownership");
-      emit OwnerChanged(owner, nominatedOwner);
-      owner = nominatedOwner;
-      nominatedOwner = address(0);
-   }
-   
-   function setCaptain(address newCaptain) external isOwner {
-      emit SetCaptain(captain,newCaptain);
-      captain=newCaptain;
-   }
-   
-   function setFirstOfficer(address newFirstOfficer) external isOwner {
-      emit SetFirstOfficer(firstOfficer,newFirstOfficer);
-      firstOfficer=newFirstOfficer;
-   }    
-   
-   function setCrewmember(address crewmember, bool set) external isOwner {
-      crewmembers[crewmember]=set;
-      emit SetCrewmember(crewmember,set);
-   }   
+    uint256 constant MAX_FEE_RATE = 100; // Max fee rate is 1%
+    uint256 constant MAX_FEE_MIN = 100e18; // Max minimum fee is 100 tokens
+    uint256 constant MAX_FEE_MAX = 1000e18; // Max fee is 1000 tokens
 
-   function toggleFeeExemptAddr(address addr) external isOwner {
-      fee_exempt_addrs[addr] = !fee_exempt_addrs[addr];
-      emit FeeExemptToggled(addr,fee_exempt_addrs[addr]);
-   }   
-  
-   
-   // ############## Token management ##############   
-   
-   function sendTokens(address receiver, uint amount) external isOwner {
-      require (receiver!=address(0),"Zero address not allowed");
-      TransferHelper.safeTransfer(address(token),receiver,amount);
-   }   
-   
-   // Generic proxy
-   function execute(address _to, uint256 _value, bytes calldata _data) external isOwner returns (bool, bytes memory) {
-      require(_data.length==0 || _to.code.length>0,"Can not call a function on a EOA");
-      (bool success, bytes memory result) = _to.call{value:_value}(_data);
-      return (success, result);
-   }   
-   
-   // ############## Views ##############
-   function getNextBatch(uint _start, uint max) public view returns (uint start, uint end, bytes32 hash) {
-      uint cutoffTime = block.timestamp-MIN_WAIT_PERIOD_ADD;
-      if (_start<transactions.length && transactions[_start].timestamp<cutoffTime) {
-         start=_start;
-         end=start+max-1;
-         if (end>=transactions.length) end=transactions.length-1;
-         while(transactions[end].timestamp>=cutoffTime) end--;
-         hash = getTransactionsHash(start,end);
-      }
-   }
-   
-   function getBatchData(uint start, uint end) public view returns (BatchData memory data) {
-      data.startTransactionNo = start;
-      data.transactions = new Transaction[](end-start+1);
-      for (uint i=start;i<=end;++i) {
-         data.transactions[i-start]=transactions[i];
-      }
-   }
-   
-   function getBatchAmount(uint start, uint end) public view returns (uint totalAmount) {
-      for (uint i=start;i<=end;++i) {
-         totalAmount+=transactions[i].amount;
-      }
-      totalAmount*=REDUCED_DECIMALS;
-   }
-   
-   function getTransactionsHash(uint start, uint end) public view returns (bytes32) {
-      bytes32 result = keccak256(abi.encodePacked(chainid, token, targetChain, targetToken, uint64(start)));
-      for (uint i=start;i<=end;++i) {
-         result = keccak256(abi.encodePacked(result, transactions[i].user,transactions[i].amount));
-      }
-      return result;
-   }   
-   
-   function noTransactions() public view returns (uint) {
-      return transactions.length;
-   }
-   
-   function noBatches() public view returns (uint) {
-      return batches.length;
-   }
+    uint256 public constant REDUCED_DECIMALS = 1e10;
+
+    Transaction[] public transactions;
+    mapping(uint256 => bool) public cancelled;
+    uint256 public executeIndex;
+    Batch[] public batches;
+
+    struct Transaction {
+        address user;
+        uint64 amount;
+        uint32 timestamp;
+    }
+
+    struct Batch {
+        uint64 start;
+        uint64 end;
+        uint64 departureTime;
+        uint64 status;
+        bytes32 hash;
+    }
+
+    struct BatchData {
+        uint256 startTransactionNo;
+        Transaction[] transactions;
+    }
+
+    constructor(address _token, uint256 _chainid, address _targetToken, uint256 _targetChain) {
+        //require (block.chainid==_chainid,"Wrong chain");
+        chainid = _chainid;
+        token = IERC20(_token);
+        targetToken = IERC20(_targetToken);
+        owner = msg.sender;
+        targetChain = _targetChain;
+    }
+
+    // ############## Events ##############
+
+    event Embark(address indexed sender, uint256 index, uint256 amount, uint256 amountAfterFee, uint256 timestamp);
+    event Disembark(uint256 start, uint256 end, bytes32 hash);
+    event Depart(uint256 batchNo, uint256 start, uint256 end, bytes32 hash);
+    event RemoveBatch(uint256 batchNo);
+    event DisputeBatch(uint256 batchNo, bytes32 hash);
+    event Cancelled(uint256 index, bool cancel);
+    event Pause(bool paused);
+    event OwnerNominated(address indexed newOwner);
+    event OwnerChanged(address indexed previousOwner, address indexed newOwner);
+    event SetCaptain(address indexed previousCaptain, address indexed newCaptain);
+    event SetFirstOfficer(address indexed previousFirstOfficer, address indexed newFirstOfficer);
+    event SetCrewmember(address indexed crewmember, bool set);
+    event SetFee(
+        uint256 previousFeeRate,
+        uint256 feeRate,
+        uint256 previousFeeMin,
+        uint256 feeMin,
+        uint256 previousFeeMax,
+        uint256 feeMax
+    );
+    event SetMinWaitPeriods(
+        uint256 previousMinWaitAdd,
+        uint256 previousMinWaitExecute,
+        uint256 minWaitAdd,
+        uint256 minWaitExecute
+    );
+    event FeeExemptToggled(address addr, bool is_fee_exempt);
+
+    // ############## Modifiers ##############
+
+    modifier isOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    modifier isCaptain() {
+        require(msg.sender == captain, "Not captain");
+        _;
+    }
+
+    modifier isFirstOfficer() {
+        require(msg.sender == firstOfficer, "Not first officer");
+        _;
+    }
+
+    modifier isCrewmember() {
+        require(
+            crewmembers[msg.sender] || msg.sender == owner || msg.sender == captain || msg.sender == firstOfficer,
+            "Not crewmember"
+        );
+        _;
+    }
+
+    modifier notPaused() {
+        require(!paused, "Paused");
+        _;
+    }
+
+    // ############## Ferry actions ##############
+
+    function embarkWithRecipient(uint256 amount, address recipient) public notPaused {
+        amount = (amount / REDUCED_DECIMALS) * REDUCED_DECIMALS; // Round amount to fit in data structure
+        uint256 fee;
+        if (fee_exempt_addrs[msg.sender]) fee = 0;
+        else fee = Math.min(Math.max(FEE_MIN, (amount * FEE_RATE) / 10_000), FEE_MAX);
+        require(amount > fee, "Amount too low");
+        require(amount / REDUCED_DECIMALS <= type(uint64).max, "Amount too high");
+        TransferHelper.safeTransferFrom(address(token), msg.sender, address(this), amount);
+        uint64 amountAfterFee = uint64((amount - fee) / REDUCED_DECIMALS);
+        emit Embark(recipient, transactions.length, amount, amountAfterFee * REDUCED_DECIMALS, block.timestamp);
+        transactions.push(Transaction(recipient, amountAfterFee, uint32(block.timestamp)));
+    }
+
+    function embark(uint256 amount) public {
+        embarkWithRecipient(amount, msg.sender);
+    }
+
+    function embarkWithSignature(
+        uint256 _amount,
+        address recipient,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        uint256 amount = approveMax ? type(uint256).max : _amount;
+        IERC20Permit(address(token)).permit(msg.sender, address(this), amount, deadline, v, r, s);
+        embarkWithRecipient(amount, recipient);
+    }
+
+    function depart(uint256 start, uint256 end, bytes32 hash) external notPaused isCaptain {
+        require(
+            (batches.length == 0 && start == 0) || (batches.length > 0 && start == batches[batches.length - 1].end + 1),
+            "Wrong start"
+        );
+        require(end >= start && end < type(uint64).max, "Wrong end");
+        batches.push(Batch(uint64(start), uint64(end), uint64(block.timestamp), 0, hash));
+        emit Depart(batches.length - 1, start, end, hash);
+    }
+
+    function disembark(BatchData calldata batchData) external notPaused isFirstOfficer {
+        Batch memory batch = batches[executeIndex++];
+        require(batch.status == 0, "Batch disputed");
+        require(batch.start == batchData.startTransactionNo, "Wrong start");
+        require(batch.start + batchData.transactions.length - 1 == batch.end, "Wrong size");
+        require(block.timestamp - batch.departureTime >= MIN_WAIT_PERIOD_EXECUTE, "Too soon");
+
+        bytes32 hash = keccak256(abi.encodePacked(targetChain, targetToken, chainid, token, batch.start));
+        for (uint256 i = 0; i < batchData.transactions.length; ++i) {
+            if (!cancelled[batch.start + i]) {
+                TransferHelper.safeTransfer(
+                    address(token),
+                    batchData.transactions[i].user,
+                    batchData.transactions[i].amount * REDUCED_DECIMALS
+                );
+            }
+            hash = keccak256(abi.encodePacked(hash, batchData.transactions[i].user, batchData.transactions[i].amount));
+        }
+        require(batch.hash == hash, "Wrong hash");
+        emit Disembark(batch.start, batch.end, hash);
+    }
+
+    function removeBatches(uint256 batchNo) external isOwner {
+        require(executeIndex <= batchNo, "Batch already executed");
+        while (batches.length > batchNo) batches.pop();
+        emit RemoveBatch(batchNo);
+    }
+
+    function disputeBatch(uint256 batchNo, bytes32 hash) external isCrewmember {
+        require(batches[batchNo].hash == hash, "Wrong hash");
+        require(executeIndex <= batchNo, "Batch already executed");
+        require(batches[batchNo].status == 0, "Batch already disputed");
+        batches[batchNo].status = 1; // Set status on disputed
+        _pause(true);
+        emit DisputeBatch(batchNo, hash);
+    }
+
+    function pause() external isCrewmember {
+        _pause(true);
+    }
+
+    function unPause() external isOwner {
+        _pause(false);
+    }
+
+    function _pause(bool _paused) internal {
+        paused = _paused;
+        emit Pause(_paused);
+    }
+
+    function _jettison(uint256 index, bool cancel) internal {
+        require(executeIndex == 0 || index > batches[executeIndex - 1].end, "Transaction already executed");
+        cancelled[index] = cancel;
+        emit Cancelled(index, cancel);
+    }
+
+    function jettison(uint256 index, bool cancel) external isOwner {
+        _jettison(index, cancel);
+    }
+
+    function jettisonGroup(uint256[] calldata indexes, bool cancel) external isOwner {
+        for (uint256 i = 0; i < indexes.length; ++i) {
+            _jettison(indexes[i], cancel);
+        }
+    }
+
+    // ############## Parameters management ##############
+
+    function setFee(uint256 _FEE_RATE, uint256 _FEE_MIN, uint256 _FEE_MAX) external isOwner {
+        require(_FEE_RATE < MAX_FEE_RATE);
+        require(_FEE_MIN < MAX_FEE_MIN);
+        require(_FEE_MAX < MAX_FEE_MAX);
+        emit SetFee(FEE_RATE, _FEE_RATE, FEE_MIN, _FEE_MIN, FEE_MAX, _FEE_MAX);
+        FEE_RATE = _FEE_RATE;
+        FEE_MIN = _FEE_MIN;
+        FEE_MAX = _FEE_MAX;
+    }
+
+    function setMinWaitPeriods(uint256 _MIN_WAIT_PERIOD_ADD, uint256 _MIN_WAIT_PERIOD_EXECUTE) external isOwner {
+        require(_MIN_WAIT_PERIOD_ADD >= 3600 && _MIN_WAIT_PERIOD_EXECUTE >= 3600, "Period too short");
+        emit SetMinWaitPeriods(
+            MIN_WAIT_PERIOD_ADD,
+            MIN_WAIT_PERIOD_EXECUTE,
+            _MIN_WAIT_PERIOD_ADD,
+            _MIN_WAIT_PERIOD_EXECUTE
+        );
+        MIN_WAIT_PERIOD_ADD = _MIN_WAIT_PERIOD_ADD;
+        MIN_WAIT_PERIOD_EXECUTE = _MIN_WAIT_PERIOD_EXECUTE;
+    }
+
+    // ############## Roles management ##############
+
+    function nominateNewOwner(address newOwner) external isOwner {
+        nominatedOwner = newOwner;
+        emit OwnerNominated(newOwner);
+    }
+
+    function acceptOwnership() external {
+        require(msg.sender == nominatedOwner, "You must be nominated before you can accept ownership");
+        emit OwnerChanged(owner, nominatedOwner);
+        owner = nominatedOwner;
+        nominatedOwner = address(0);
+    }
+
+    function setCaptain(address newCaptain) external isOwner {
+        emit SetCaptain(captain, newCaptain);
+        captain = newCaptain;
+    }
+
+    function setFirstOfficer(address newFirstOfficer) external isOwner {
+        emit SetFirstOfficer(firstOfficer, newFirstOfficer);
+        firstOfficer = newFirstOfficer;
+    }
+
+    function setCrewmember(address crewmember, bool set) external isOwner {
+        crewmembers[crewmember] = set;
+        emit SetCrewmember(crewmember, set);
+    }
+
+    function toggleFeeExemptAddr(address addr) external isOwner {
+        fee_exempt_addrs[addr] = !fee_exempt_addrs[addr];
+        emit FeeExemptToggled(addr, fee_exempt_addrs[addr]);
+    }
+
+    // ############## Token management ##############
+
+    function sendTokens(address receiver, uint256 amount) external isOwner {
+        require(receiver != address(0), "Zero address not allowed");
+        TransferHelper.safeTransfer(address(token), receiver, amount);
+    }
+
+    // Generic proxy
+    function execute(address _to, uint256 _value, bytes calldata _data) external isOwner returns (bool, bytes memory) {
+        require(_data.length == 0 || _to.code.length > 0, "Can not call a function on a EOA");
+        (bool success, bytes memory result) = _to.call{ value: _value }(_data);
+        return (success, result);
+    }
+
+    // ############## Views ##############
+    function getNextBatch(uint256 _start, uint256 max) public view returns (uint256 start, uint256 end, bytes32 hash) {
+        uint256 cutoffTime = block.timestamp - MIN_WAIT_PERIOD_ADD;
+        if (_start < transactions.length && transactions[_start].timestamp < cutoffTime) {
+            start = _start;
+            end = start + max - 1;
+            if (end >= transactions.length) end = transactions.length - 1;
+            while (transactions[end].timestamp >= cutoffTime) end--;
+            hash = getTransactionsHash(start, end);
+        }
+    }
+
+    function getBatchData(uint256 start, uint256 end) public view returns (BatchData memory data) {
+        data.startTransactionNo = start;
+        data.transactions = new Transaction[](end - start + 1);
+        for (uint256 i = start; i <= end; ++i) {
+            data.transactions[i - start] = transactions[i];
+        }
+    }
+
+    function getBatchAmount(uint256 start, uint256 end) public view returns (uint256 totalAmount) {
+        for (uint256 i = start; i <= end; ++i) {
+            totalAmount += transactions[i].amount;
+        }
+        totalAmount *= REDUCED_DECIMALS;
+    }
+
+    function getTransactionsHash(uint256 start, uint256 end) public view returns (bytes32) {
+        bytes32 result = keccak256(abi.encodePacked(chainid, token, targetChain, targetToken, uint64(start)));
+        for (uint256 i = start; i <= end; ++i) {
+            result = keccak256(abi.encodePacked(result, transactions[i].user, transactions[i].amount));
+        }
+        return result;
+    }
+
+    function noTransactions() public view returns (uint256) {
+        return transactions.length;
+    }
+
+    function noBatches() public view returns (uint256) {
+        return batches.length;
+    }
 }

--- a/src/contracts/FrxEthRewarder.sol
+++ b/src/contracts/FrxEthRewarder.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.20;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+
+contract FrxEthRewarder is Ownable, ReentrancyGuard {
+    uint256 public rewardAmount;
+    address public bot;
+    mapping(address user => bool yes) public rewarded;
+
+    event RewardBridger(address bridger, uint256 amount);
+
+    constructor() Ownable(msg.sender) {}
+
+    // -----------------------------------------------------------------------
+    //                               ONLY-BOT
+    // -----------------------------------------------------------------------
+
+    /// @notice reward bridgers a fixed amount of frxETH
+    /// @notice On duplicates, the loop continues to the next address to prevent halts
+    function rewardBridgers(address[] memory bridgers) external nonReentrant {
+        require(msg.sender == bot);
+
+        uint256 length = bridgers.length;
+        uint256 rewardAmount_ = rewardAmount;
+        for (uint256 i = 0; i < length; ) {
+            address bridger = bridgers[i];
+            if (!rewarded[bridger]) {
+                rewarded[bridger] = true;
+                // Do nothing if the recipient is a contract - to only reward EOA
+                if (bridger.code.length != 0) continue;
+                // Assume the call is a success
+                payable(bridger).call{ value: rewardAmount_ }("");
+
+                emit RewardBridger(bridger, rewardAmount_);
+            }
+
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    //                              ONLY-OWNER
+    // -----------------------------------------------------------------------
+
+    function setRewardAmount(uint256 _newRewardAmount) external onlyOwner {
+        rewardAmount = _newRewardAmount;
+    }
+
+    function setBot(address _newBot) external onlyOwner {
+        bot = _newBot;
+    }
+
+    function withdrawFrxEth(address recipient, uint256 amount) onlyOwner {
+        (bool success, ) = payable(recipient).call{ value: amount }("");
+        require(success, "ETH Transfer failed");
+    }
+}


### PR DESCRIPTION
Creates a basic `FrxEthRewarder` contract to reward bridgers a fixed amount of frxETH on bridging.

Stores a mapping of addresses rewarded to prevent double-rewards.

Requires a bot with off-chain reads of ferry recipients to pass in the array of recipients to reward.

cc @0xJM 